### PR TITLE
Added a way to provide the real NSURLSession to be used

### DIFF
--- a/DVR/Session.swift
+++ b/DVR/Session.swift
@@ -6,16 +6,18 @@ public class Session: NSURLSession {
 
     public var outputDirectory: String
     public let cassetteName: String
+    public let realSession: NSURLSession
     public var recordingEnabled = true
     private let testBundle: NSBundle
 
 
     // MARK: - Initializers
 
-    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: NSBundle = NSBundle.allBundles().filter() { $0.bundlePath.hasSuffix(".xctest") }.first!) {
+    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: NSBundle = NSBundle.allBundles().filter() { $0.bundlePath.hasSuffix(".xctest") }.first!, realSession: NSURLSession = NSURLSession.sharedSession()) {
         self.outputDirectory = outputDirectory
         self.cassetteName = cassetteName
         self.testBundle = testBundle
+        self.realSession = realSession
         super.init()
     }
 

--- a/DVR/Session.swift
+++ b/DVR/Session.swift
@@ -6,18 +6,18 @@ public class Session: NSURLSession {
 
     public var outputDirectory: String
     public let cassetteName: String
-    public let realSession: NSURLSession
+    public let backingSession: NSURLSession
     public var recordingEnabled = true
     private let testBundle: NSBundle
 
 
     // MARK: - Initializers
 
-    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: NSBundle = NSBundle.allBundles().filter() { $0.bundlePath.hasSuffix(".xctest") }.first!, realSession: NSURLSession = NSURLSession.sharedSession()) {
+    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: NSBundle = NSBundle.allBundles().filter() { $0.bundlePath.hasSuffix(".xctest") }.first!, backingSession: NSURLSession = NSURLSession.sharedSession()) {
         self.outputDirectory = outputDirectory
         self.cassetteName = cassetteName
         self.testBundle = testBundle
-        self.realSession = realSession
+        self.backingSession = backingSession
         super.init()
     }
 

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -48,7 +48,7 @@ class SessionDataTask: NSURLSessionDataTask {
 
         print("[DVR] Recording '\(session.cassetteName)'")
 
-        let task = NSURLSession.sharedSession().dataTaskWithRequest(request) { data, response, error in
+        let task = session.realSession.dataTaskWithRequest(request) { data, response, error in
             // Create cassette
             let interaction = Interaction(request: self.request, response: response!, responseData: data)
             let cassette = Cassette(name: self.session.cassetteName, interactions: [interaction])

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -48,7 +48,7 @@ class SessionDataTask: NSURLSessionDataTask {
 
         print("[DVR] Recording '\(session.cassetteName)'")
 
-        let task = session.realSession.dataTaskWithRequest(request) { data, response, error in
+        let task = session.backingSession.dataTaskWithRequest(request) { data, response, error in
             // Create cassette
             let interaction = Interaction(request: self.request, response: response!, responseData: data)
             let cassette = Cassette(name: self.session.cassetteName, interactions: [interaction])


### PR DESCRIPTION
Added a way to provide the real session to be used when an appropriate `Casette` is not yet present. This is useful when e.g. talking to servers that require the client responds to an authentication challenge, which `NSURLSession.defaultSession()` doesn't. Now you have a way to pass in your own session which responds e.g. with the right credentials, so that the first recording can go through.

Btw, great work on this framework! I really like the paradigm and we're now starting to test APIs this way in our [`XcodeServerSDK`](https://github.com/czechboy0/XcodeServerSDK) project. Thanks for putting this out here.
