### PR TITLE
Handling nil response a bit more gracefully

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -49,8 +49,14 @@ class SessionDataTask: NSURLSessionDataTask {
         print("[DVR] Recording '\(session.cassetteName)'")
 
         let task = session.backingSession.dataTaskWithRequest(request) { data, response, error in
+            
+            //Ensure we have a response
+            guard let response = response else {
+                fatalError("[DVR] Failed to persist cassette, because the task returned a nil response.")
+            }
+            
             // Create cassette
-            let interaction = Interaction(request: self.request, response: response!, responseData: data)
+            let interaction = Interaction(request: self.request, response: response, responseData: data)
             let cassette = Cassette(name: self.session.cassetteName, interactions: [interaction])
 
             // Persist


### PR DESCRIPTION
Made the problem when response is `nil` a bit more obvious (+ removed a forced unwrap, FTW!) I encountered this when https failed to validate a certificate - `response` was nil, which crashed on the force unwrap during the creation of `Interaction`. If this happens now, it should be a bit more obvy.
