### PR TITLE
Plain text serialization for JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build

--- a/DVR.podspec
+++ b/DVR.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "DVR"
-  s.version      = "0.0.2-czechboy0"
+  s.version      = "0.0.3-czechboy0"
   s.summary      = "Network testing for Swift"
 
   s.description  = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   # s.watchos.deployment_target = "2.0"
 
-  s.source       = { :git => "https://github.com/czechboy0/DVR.git", :tag => "v0.0.2-czechboy0" }
+  s.source       = { :git => "https://github.com/czechboy0/DVR.git", :tag => "v0.0.3-czechboy0" }
 
   s.source_files  = "DVR/*.{swift}"
 

--- a/DVR.podspec
+++ b/DVR.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+
+  s.name         = "DVR"
+  s.version      = "0.0.2-czechboy0"
+  s.summary      = "Network testing for Swift"
+
+  s.description  = <<-DESC
+                   DVR is a simple Swift framework for making fake NSURLSession requests based on VCR for iOS, watchOS, and OS X.
+                   DESC
+
+  s.homepage     = "https://github.com/czechboy0/DVR"
+
+  s.author             = { "Honza Dvorsky" => "https://github.com/czechboy0" }
+  
+  s.license      = { :type => "MIT", :file => "LICENSE.md" }
+
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.10"
+  # s.watchos.deployment_target = "2.0"
+
+  s.source       = { :git => "https://github.com/czechboy0/DVR.git", :tag => "v0.0.2-czechboy0" }
+
+  s.source_files  = "DVR/*.{swift}"
+
+end

--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -37,6 +37,11 @@
 		3690A0A01B33AA9400731222 /* URLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFBF1B33602A00EF10D4 /* URLResponse.swift */; };
 		3690A0A11B33AA9400731222 /* URLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFC11B3363C400EF10D4 /* URLHTTPResponse.swift */; };
 		3690A0A21B33AA9E00731222 /* SessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFCB1B33689000EF10D4 /* SessionTests.swift */; };
+		3AA8597C1B473EB500B66772 /* DataSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA8597B1B473EB500B66772 /* DataSerialization.swift */; };
+		3AA8597D1B473EB500B66772 /* DataSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA8597B1B473EB500B66772 /* DataSerialization.swift */; };
+		3AA8597E1B473EB500B66772 /* DataSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA8597B1B473EB500B66772 /* DataSerialization.swift */; };
+		3AA859801B4740CB00B66772 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA8597F1B4740CB00B66772 /* RequestTests.swift */; };
+		3AA859811B4740CB00B66772 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA8597F1B4740CB00B66772 /* RequestTests.swift */; };
 		3AFCECC21B3F64170060BE1A /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFCECC11B3F64170060BE1A /* ResponseTests.swift */; };
 		3AFCECC31B3F64170060BE1A /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFCECC11B3F64170060BE1A /* ResponseTests.swift */; };
 /* End PBXBuildFile section */
@@ -76,6 +81,8 @@
 		3690A06E1B33AA0900731222 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3690A07B1B33AA3B00731222 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3690A0841B33AA3C00731222 /* DVRTests-OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DVRTests-OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AA8597B1B473EB500B66772 /* DataSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerialization.swift; sourceTree = "<group>"; };
+		3AA8597F1B4740CB00B66772 /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		3AFCECC11B3F64170060BE1A /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -144,13 +151,14 @@
 			isa = PBXGroup;
 			children = (
 				3647AF9E1B335D5500EF10D4 /* DVR.h */,
+				3647AFB51B335E4A00EF10D4 /* Cassette.swift */,
+				3AA8597B1B473EB500B66772 /* DataSerialization.swift */,
+				3647AFB61B335E4A00EF10D4 /* Interaction.swift */,
 				3647AFB81B335E4A00EF10D4 /* Session.swift */,
 				3647AFB91B335E4A00EF10D4 /* SessionDataTask.swift */,
-				3647AFB51B335E4A00EF10D4 /* Cassette.swift */,
-				3647AFB61B335E4A00EF10D4 /* Interaction.swift */,
+				3647AFC11B3363C400EF10D4 /* URLHTTPResponse.swift */,
 				3647AFB71B335E4A00EF10D4 /* URLRequest.swift */,
 				3647AFBF1B33602A00EF10D4 /* URLResponse.swift */,
-				3647AFC11B3363C400EF10D4 /* URLHTTPResponse.swift */,
 				3647AFC71B33688A00EF10D4 /* Resources */,
 				3647AFCA1B33689000EF10D4 /* Tests */,
 			);
@@ -168,10 +176,11 @@
 		3647AFCA1B33689000EF10D4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				3647AFCF1B33693F00EF10D4 /* Fixtures */,
-				3647AFCB1B33689000EF10D4 /* SessionTests.swift */,
-				3AFCECC11B3F64170060BE1A /* ResponseTests.swift */,
 				3647AFCC1B33689000EF10D4 /* Info.plist */,
+				3AA8597F1B4740CB00B66772 /* RequestTests.swift */,
+				3AFCECC11B3F64170060BE1A /* ResponseTests.swift */,
+				3647AFCB1B33689000EF10D4 /* SessionTests.swift */,
+				3647AFCF1B33693F00EF10D4 /* Fixtures */,
 			);
 			name = Tests;
 			path = DVR/Tests;
@@ -400,6 +409,7 @@
 			files = (
 				3647AFC01B33602A00EF10D4 /* URLResponse.swift in Sources */,
 				3647AFBE1B335E4A00EF10D4 /* SessionDataTask.swift in Sources */,
+				3AA8597C1B473EB500B66772 /* DataSerialization.swift in Sources */,
 				3647AFBD1B335E4A00EF10D4 /* Session.swift in Sources */,
 				3647AFBC1B335E4A00EF10D4 /* URLRequest.swift in Sources */,
 				3647AFBB1B335E4A00EF10D4 /* Interaction.swift in Sources */,
@@ -412,6 +422,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AA859801B4740CB00B66772 /* RequestTests.swift in Sources */,
 				3AFCECC21B3F64170060BE1A /* ResponseTests.swift in Sources */,
 				3647AFCD1B33689000EF10D4 /* SessionTests.swift in Sources */,
 			);
@@ -423,6 +434,7 @@
 			files = (
 				3690A09E1B33AA9400731222 /* Interaction.swift in Sources */,
 				3690A09D1B33AA9400731222 /* Cassette.swift in Sources */,
+				3AA8597D1B473EB500B66772 /* DataSerialization.swift in Sources */,
 				3690A0A01B33AA9400731222 /* URLResponse.swift in Sources */,
 				3690A09B1B33AA9400731222 /* Session.swift in Sources */,
 				3690A09C1B33AA9400731222 /* SessionDataTask.swift in Sources */,
@@ -437,6 +449,7 @@
 			files = (
 				3690A0961B33AA9400731222 /* Interaction.swift in Sources */,
 				3690A0951B33AA9400731222 /* Cassette.swift in Sources */,
+				3AA8597E1B473EB500B66772 /* DataSerialization.swift in Sources */,
 				3690A0981B33AA9400731222 /* URLResponse.swift in Sources */,
 				3690A0931B33AA9400731222 /* Session.swift in Sources */,
 				3690A0941B33AA9400731222 /* SessionDataTask.swift in Sources */,
@@ -449,6 +462,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AA859811B4740CB00B66772 /* RequestTests.swift in Sources */,
 				3AFCECC31B3F64170060BE1A /* ResponseTests.swift in Sources */,
 				3690A0A21B33AA9E00731222 /* SessionTests.swift in Sources */,
 			);

--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		3690A0A01B33AA9400731222 /* URLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFBF1B33602A00EF10D4 /* URLResponse.swift */; };
 		3690A0A11B33AA9400731222 /* URLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFC11B3363C400EF10D4 /* URLHTTPResponse.swift */; };
 		3690A0A21B33AA9E00731222 /* SessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFCB1B33689000EF10D4 /* SessionTests.swift */; };
+		3AFCECC21B3F64170060BE1A /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFCECC11B3F64170060BE1A /* ResponseTests.swift */; };
+		3AFCECC31B3F64170060BE1A /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFCECC11B3F64170060BE1A /* ResponseTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +76,7 @@
 		3690A06E1B33AA0900731222 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3690A07B1B33AA3B00731222 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3690A0841B33AA3C00731222 /* DVRTests-OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DVRTests-OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AFCECC11B3F64170060BE1A /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +170,7 @@
 			children = (
 				3647AFCF1B33693F00EF10D4 /* Fixtures */,
 				3647AFCB1B33689000EF10D4 /* SessionTests.swift */,
+				3AFCECC11B3F64170060BE1A /* ResponseTests.swift */,
 				3647AFCC1B33689000EF10D4 /* Info.plist */,
 			);
 			name = Tests;
@@ -408,6 +412,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AFCECC21B3F64170060BE1A /* ResponseTests.swift in Sources */,
 				3647AFCD1B33689000EF10D4 /* SessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -444,6 +449,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AFCECC31B3F64170060BE1A /* ResponseTests.swift in Sources */,
 				3690A0A21B33AA9E00731222 /* SessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -593,16 +599,19 @@
 		3647AFB31B335D5500EF10D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.iostests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		3647AFB41B335D5500EF10D4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.iostests;
@@ -691,6 +700,7 @@
 		3690A0901B33AA3C00731222 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -698,12 +708,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.osxtests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		3690A0911B33AA3C00731222 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/DVR/DataSerialization.swift
+++ b/DVR/DataSerialization.swift
@@ -1,0 +1,58 @@
+//
+//  DataSerialization.swift
+//  DVR
+//
+//  Created by Honza Dvorsky on 04/07/2015.
+//  Copyright © 2015 Venmo. All rights reserved.
+//
+
+import Foundation
+
+// Identifies the way data was persisted on disk
+enum SerializationFormat: String {
+    case JSON = "json"
+    case PlainText = "plain_text"
+    case Base64String = "base64_string" //legacy default
+}
+
+// Body data serialization
+class DataSerialization {
+    
+    static func serializeBodyData(data: NSData, contentType: String?) -> (format: SerializationFormat, object: AnyObject) {
+        
+        //JSON
+        if let contentType = contentType where contentType.hasPrefix("application/json") {
+            do {
+                let json = try NSJSONSerialization.JSONObjectWithData(data, options: [.AllowFragments])
+                return (format: .JSON, json)
+            } catch { /* nope, not a valid json. nevermind. */ }
+        }
+        
+        //Plain Text
+        if let contentType = contentType where contentType.hasPrefix("text") {
+            if let string = NSString(data: data, encoding: NSUTF8StringEncoding) {
+                return (format: .PlainText, object: string)
+            }
+        }
+        
+        //nope, might be image data or something else
+        //no prettier representation, fall back to base64 string
+        let string = data.base64EncodedStringWithOptions([])
+        return (format: .Base64String, object: string)
+    }
+    
+    static func deserializeBodyData(format: SerializationFormat, object: AnyObject) -> NSData {
+        
+        switch format {
+        case .JSON:
+            do {
+                return try NSJSONSerialization.dataWithJSONObject(object, options: [])
+            } catch { fatalError("Failed to convert JSON object \(object) into data") }
+        case .PlainText:
+            return (object as! String).dataUsingEncoding(NSUTF8StringEncoding)!
+        case .Base64String:
+            return NSData(base64EncodedString: object as! String, options: [])!
+        }
+    }
+    
+}

--- a/DVR/Session.swift
+++ b/DVR/Session.swift
@@ -24,11 +24,11 @@ public class Session: NSURLSession {
 
     // MARK: - NSURLSession
 
-    public override func dataTaskWithRequest(request: NSURLRequest) -> NSURLSessionDataTask? {
+    public override func dataTaskWithRequest(request: NSURLRequest) -> NSURLSessionDataTask {
         return SessionDataTask(session: self, request: request)
     }
 
-    public override func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
+    public override func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {
         return SessionDataTask(session: self, request: request, completion: completionHandler)
     }
     

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -75,6 +75,6 @@ class SessionDataTask: NSURLSessionDataTask {
 
 			fatalError("[DVR] Failed to persist cassette.")
         }
-        task?.resume()
+        task.resume()
     }
 }

--- a/DVR/Tests/ResponseTests.swift
+++ b/DVR/Tests/ResponseTests.swift
@@ -1,0 +1,111 @@
+//
+//  ResponseTests.swift
+//  DVR
+//
+//  Created by Honza Dvorsky on 28/06/2015.
+//  Copyright © 2015 Venmo. All rights reserved.
+//
+
+import XCTest
+@testable
+import DVR
+
+class ResponseTests: XCTestCase {
+
+    func testDataSerialization_JSON() {
+        
+        let object: NSDictionary = [
+            "testing": "rules"
+        ]
+        let data = try! NSJSONSerialization.dataWithJSONObject(object, options: [])
+        let interaction = Interaction(request: NSURLRequest(), response: NSURLResponse(), responseData: data)
+        
+        let dictionary = interaction.dictionary["response"] as! NSDictionary
+        XCTAssertNotNil(dictionary["body"])
+        XCTAssertNotNil(dictionary["body_format"])
+        XCTAssertEqual(dictionary["body"] as! NSDictionary, object)
+        XCTAssertEqual(dictionary["body_format"] as! String, Interaction.SerializationFormat.JSON.rawValue)
+    }
+    
+    func testDataSerialization_Base64() {
+        
+        let object: String = "testing_rules"
+        let data = object.dataUsingEncoding(NSUTF8StringEncoding)!
+        let base64String = data.base64EncodedStringWithOptions([])
+        let interaction = Interaction(request: NSURLRequest(), response: NSURLResponse(), responseData: data)
+        
+        let dictionary = interaction.dictionary["response"] as! NSDictionary
+        XCTAssertNotNil(dictionary["body"])
+        XCTAssertNotNil(dictionary["body_format"])
+        XCTAssertEqual(dictionary["body"] as! String, base64String)
+        XCTAssertEqual(dictionary["body_format"] as! String, Interaction.SerializationFormat.Base64String.rawValue)
+    }
+    
+    func testDataDeserialization_JSON() {
+        
+        let json: NSDictionary = [
+            "testing": "rules?"
+        ]
+        let response: [String: AnyObject] = [
+            "body": json,
+            "body_format": Interaction.SerializationFormat.JSON.rawValue
+        ]
+        
+        let dictionary: [String: AnyObject] = [
+            "request": [String: AnyObject](),
+            "recorded_at": 12345,
+            "response": response
+        ]
+        
+        let interaction = Interaction(dictionary: dictionary)!
+        let data = interaction.responseData!
+        let parsed = try! NSJSONSerialization.JSONObjectWithData(data, options: [.AllowFragments]) as! NSDictionary
+        XCTAssertEqual(json, parsed)
+    }
+    
+    func testDataDeserialization_Base64() {
+        
+        let string = "testing_rules?"
+        let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
+        let base64String = data.base64EncodedStringWithOptions([])
+        let response: [String: AnyObject] = [
+            "body": base64String,
+            "body_format": Interaction.SerializationFormat.Base64String.rawValue
+        ]
+        
+        let dictionary: [String: AnyObject] = [
+            "request": [String: AnyObject](),
+            "recorded_at": 12345,
+            "response": response
+        ]
+        
+        let interaction = Interaction(dictionary: dictionary)!
+        let responseData = interaction.responseData!
+        
+        let parsed = NSString(data: responseData, encoding: NSUTF8StringEncoding)!
+        XCTAssertEqual(string, parsed)
+    }
+    
+    func testDataDeserialization_defaultsToBase64() {
+        
+        let string = "no_format_specified, so base64 is assumed!"
+        let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
+        let base64String = data.base64EncodedStringWithOptions([])
+        let response: [String: AnyObject] = [
+            "body": base64String
+        ]
+        
+        let dictionary: [String: AnyObject] = [
+            "request": [String: AnyObject](),
+            "recorded_at": 12345,
+            "response": response
+        ]
+        
+        let interaction = Interaction(dictionary: dictionary)!
+        let responseData = interaction.responseData!
+        
+        let parsed = NSString(data: responseData, encoding: NSUTF8StringEncoding)!
+        XCTAssertEqual(string, parsed)
+    }
+    
+}

--- a/DVR/Tests/SessionTests.swift
+++ b/DVR/Tests/SessionTests.swift
@@ -27,7 +27,7 @@ class SessionTests: XCTestCase {
 
             expectation.fulfill()
         }
-        task?.resume()
+        task.resume()
         waitForExpectationsWithTimeout(1, handler: nil)
     }
 }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Honza Dvorsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
Added different serialization to different data types. JSON is now serialized in plain text, so that it's more readable. Other types fall back to base64 as before. Includes tests.
