### PR TITLE
Cassette improvements

### DIFF
--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		3690A0A01B33AA9400731222 /* URLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFBF1B33602A00EF10D4 /* URLResponse.swift */; };
 		3690A0A11B33AA9400731222 /* URLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFC11B3363C400EF10D4 /* URLHTTPResponse.swift */; };
 		3690A0A21B33AA9E00731222 /* SessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFCB1B33689000EF10D4 /* SessionTests.swift */; };
+		36BDDB891B6716AB00878665 /* json-example.json in Resources */ = {isa = PBXBuildFile; fileRef = 36BDDB881B6716AB00878665 /* json-example.json */; };
+		36BDDB8A1B6716AB00878665 /* json-example.json in Resources */ = {isa = PBXBuildFile; fileRef = 36BDDB881B6716AB00878665 /* json-example.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +80,7 @@
 		3690A06E1B33AA0900731222 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3690A07B1B33AA3B00731222 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3690A0841B33AA3C00731222 /* DVRTests-OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DVRTests-OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		36BDDB881B6716AB00878665 /* json-example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "json-example.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +184,7 @@
 		3647AFCF1B33693F00EF10D4 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				36BDDB881B6716AB00878665 /* json-example.json */,
 				215F927C1B33D46C00EDC60F /* example.json */,
 			);
 			path = Fixtures;
@@ -366,6 +370,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				36BDDB891B6716AB00878665 /* json-example.json in Resources */,
 				215F927D1B33D46C00EDC60F /* example.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -388,6 +393,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				36BDDB8A1B6716AB00878665 /* json-example.json in Resources */,
 				215F927E1B33D46C00EDC60F /* example.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DVR/Interaction.swift
+++ b/DVR/Interaction.swift
@@ -1,16 +1,73 @@
 import Foundation
 
 struct Interaction {
+
+    // MARK: - Properties
+
     let request: NSURLRequest
     let response: NSURLResponse
     let responseData: NSData?
     let recordedAt: NSDate
+
+
+    // MARK: - Initializers
 
     init(request: NSURLRequest, response: NSURLResponse, responseData: NSData? = nil, recordedAt: NSDate = NSDate()) {
         self.request = request
         self.response = response
         self.responseData = responseData
         self.recordedAt = recordedAt
+    }
+
+
+    // MARK: - Encoding
+
+    static func encodeBody(body: NSData, headers: [String: String]? = nil) -> AnyObject? {
+        if let contentType = headers?["Content-Type"] {
+            // Text
+            if contentType.hasPrefix("text/") {
+                // TODO: Use encoding if specified in headers
+                return String(NSString(data: body, encoding: NSUTF8StringEncoding))
+            }
+
+            // JSON
+            if contentType == "application/json" {
+                do {
+                    return try NSJSONSerialization.JSONObjectWithData(body, options: [])
+                } catch {
+                    return nil
+                }
+            }
+        }
+
+        // Base64
+        return body.base64EncodedStringWithOptions([])
+    }
+
+    static func dencodeBody(body: AnyObject?, headers: [String: String]? = nil) -> NSData? {
+        if let contentType = headers?["Content-Type"] {
+            // Text
+            if let string = body as? String where contentType.hasPrefix("text/") {
+                // TODO: Use encoding if specified in headers
+                return string.dataUsingEncoding(NSUTF8StringEncoding)
+            }
+
+            // JSON
+            if let body = body where contentType == "application/json" {
+                do {
+                    return try NSJSONSerialization.dataWithJSONObject(body, options: [])
+                } catch {
+                    return nil
+                }
+            }
+        }
+
+        // Base64
+        if let base64 = body as? String {
+            return NSData(base64EncodedString: base64, options: [])
+        }
+
+        return nil
     }
 }
 
@@ -23,8 +80,8 @@ extension Interaction {
         ]
 
         var response = self.response.dictionary
-        if let string = responseData?.base64EncodedStringWithOptions([]) {
-            response["body"] = string
+        if let data = responseData, body = Interaction.encodeBody(data, headers: response["headers"] as? [String: String]) {
+            response["body"] = body
         }
         dictionary["response"] = response
 
@@ -39,11 +96,6 @@ extension Interaction {
         self.request = NSMutableURLRequest(dictionary: request)
         self.response = URLHTTPResponse(dictionary: response)
         self.recordedAt = NSDate(timeIntervalSince1970: NSTimeInterval(recordedAt))
-
-        if let string = response["body"] as? String {
-            self.responseData = NSData(base64EncodedString: string, options: [])
-        } else {
-            self.responseData = nil
-        }
+        self.responseData = Interaction.dencodeBody(response["body"], headers: response["headers"] as? [String: String])
     }
 }

--- a/DVR/Interaction.swift
+++ b/DVR/Interaction.swift
@@ -45,6 +45,8 @@ struct Interaction {
     }
 
     static func dencodeBody(body: AnyObject?, headers: [String: String]? = nil) -> NSData? {
+        guard let body = body else { return nil }
+
         if let contentType = headers?["Content-Type"] {
             // Text
             if let string = body as? String where contentType.hasPrefix("text/") {
@@ -53,7 +55,7 @@ struct Interaction {
             }
 
             // JSON
-            if let body = body where contentType == "application/json" {
+            if contentType == "application/json" {
                 do {
                     return try NSJSONSerialization.dataWithJSONObject(body, options: [])
                 } catch {

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -72,8 +72,19 @@ class SessionDataTask: NSURLSessionDataTask {
             do {
                 let outputPath = outputDirectory.stringByAppendingPathComponent(self.session.cassetteName).stringByAppendingPathExtension("json")!
                 let data = try NSJSONSerialization.dataWithJSONObject(cassette.dictionary, options: [.PrettyPrinted])
-                data.writeToFile(outputPath, atomically: true)
-                fatalError("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")
+
+                // Add trailing new line
+                guard var string = NSString(data: data, encoding: NSUTF8StringEncoding) else {
+                    fatalError("[DVR] Failed to persist cassette.")
+                }
+                string = string.stringByAppendingString("\n")
+
+                if let data = string.dataUsingEncoding(NSUTF8StringEncoding) {
+                    data.writeToFile(outputPath, atomically: true)
+                    fatalError("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")
+                }
+
+                fatalError("[DVR] Failed to persist cassette.")
             } catch {
                 // Do nothing
             }

--- a/DVR/Tests/Fixtures/example.json
+++ b/DVR/Tests/Fixtures/example.json
@@ -3,7 +3,7 @@
     {
       "recorded_at" : 1434688721.440751,
       "response" : {
-        "body" : "aGVsbG8=",
+        "body" : "hello",
         "status" : 200,
         "url" : "http:\/\/example.com\/",
         "headers" : {

--- a/DVR/Tests/Fixtures/json-example.json
+++ b/DVR/Tests/Fixtures/json-example.json
@@ -1,0 +1,93 @@
+{
+  "interactions" : [
+    {
+      "recorded_at" : 1438048018.179753,
+      "response" : {
+        "body" : {
+          "rating" : "Bad",
+          "insecure_cipher_suites" : {
+            "TLS_RSA_WITH_RC4_128_SHA" : [
+              "use RC4 which has insecure biases in its output"
+            ],
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA" : [
+              "use RC4 which has insecure biases in its output"
+            ],
+            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA" : [
+              "use RC4 which has insecure biases in its output"
+            ],
+            "TLS_ECDH_RSA_WITH_RC4_128_SHA" : [
+              "use RC4 which has insecure biases in its output"
+            ],
+            "TLS_ECDHE_RSA_WITH_RC4_128_SHA" : [
+              "use RC4 which has insecure biases in its output"
+            ],
+            "TLS_RSA_WITH_RC4_128_MD5" : [
+              "use RC4 which has insecure biases in its output"
+            ]
+          },
+          "tls_compression_supported" : false,
+          "given_cipher_suites" : [
+            "TLS_EMPTY_RENEGOTIATION_INFO_SCSV",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_RSA_WITH_RC4_128_SHA",
+            "TLS_RSA_WITH_RC4_128_SHA",
+            "TLS_RSA_WITH_RC4_128_MD5"
+          ],
+          "session_ticket_supported" : false,
+          "unknown_cipher_suite_supported" : false,
+          "beast_vuln" : false,
+          "able_to_detect_n_minus_one_splitting" : false,
+          "tls_version" : "TLS 1.2",
+          "ephemeral_keys_supported" : true
+        },
+        "status" : 200,
+        "url" : "https:\/\/www.howsmyssl.com\/a\/check",
+        "headers" : {
+          "Date" : "Tue, 28 Jul 2015 01:46:57 GMT",
+          "Strict-Transport-Security" : "max-age=631138519; includeSubdomains; preload",
+          "Content-Length" : "2139",
+          "Connection" : "close",
+          "Content-Type" : "application\/json",
+          "Access-Control-Allow-Origin" : "*"
+        }
+      },
+      "request" : {
+        "method" : "GET",
+        "url" : "https:\/\/www.howsmyssl.com\/a\/check"
+      }
+    }
+  ],
+  "name" : "json-example"
+}

--- a/DVR/Tests/SessionTests.swift
+++ b/DVR/Tests/SessionTests.swift
@@ -32,12 +32,20 @@ class SessionTests: XCTestCase {
     }
 
     func testDownload() {
-        session.recordingEnabled = false
         let expectation = expectationWithDescription("Network")
 
+        let session = Session(cassetteName: "json-example")
+        session.recordingEnabled = false
+        let request = NSURLRequest(URL: NSURL(string: "https://www.howsmyssl.com/a/check")!)
+        
         let task = session.downloadTaskWithRequest(request) { location, response, error in
             let data = NSData(contentsOfURL: location!)!
-            XCTAssertEqual("hello", String(NSString(data: data, encoding: NSUTF8StringEncoding)!))
+            do {
+                let JSON = try NSJSONSerialization.JSONObjectWithData(data, options: []) as! [String: AnyObject]
+                XCTAssertEqual("TLS 1.2", JSON["tls_version"]! as! String)
+            } catch {
+                XCTFail("Failed to read JSON.")
+            }
 
             let HTTPResponse = response as! NSHTTPURLResponse
             XCTAssertEqual(200, HTTPResponse.statusCode)

--- a/DVR/URLRequest.swift
+++ b/DVR/URLRequest.swift
@@ -16,8 +16,8 @@ extension NSURLRequest {
             dictionary["headers"] = headers
         }
 
-        if let body = HTTPBody {
-            dictionary["body"] = body.base64EncodedStringWithOptions([])
+        if let data = HTTPBody, body = Interaction.encodeBody(data, headers: allHTTPHeaderFields) {
+            dictionary["body"] = body
         }
 
         return dictionary
@@ -41,8 +41,6 @@ extension NSMutableURLRequest {
             allHTTPHeaderFields = headers
         }
 
-        if let body = dictionary["body"] as? String {
-            HTTPBody = NSData(base64EncodedString: body, options: [])
-        }
+        HTTPBody = Interaction.dencodeBody(dictionary["body"], headers: allHTTPHeaderFields)
     }
 }


### PR DESCRIPTION
This is a simpler implementation of #5. Not sure that it's better though. If we decide we want to merge this, then I'll write a Ruby script to convert old cassettes to the new format.

If the content type begins with `text/` it is included as a string in the JSON encoding of the cassette. If they content type is `application/json`, the object is included as a nested array or dictionary in the JSON. If it's anything else, we'll continue to base64 encode it (for stuff like images, etc).

This also adds a new line to the end of cassettes :)
