### PR TITLE
Beta 5 NSString -> String issues

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -49,7 +49,7 @@ class SessionDataTask: NSURLSessionDataTask {
 		}
 
         // Create directory
-        let outputDirectory = session.outputDirectory.stringByExpandingTildeInPath
+        let outputDirectory = (session.outputDirectory as NSString).stringByExpandingTildeInPath
         let fileManager = NSFileManager.defaultManager()
         if !fileManager.fileExistsAtPath(outputDirectory) {
             try! fileManager.createDirectoryAtPath(outputDirectory, withIntermediateDirectories: true, attributes: nil)
@@ -70,7 +70,7 @@ class SessionDataTask: NSURLSessionDataTask {
 
             // Persist
             do {
-                let outputPath = outputDirectory.stringByAppendingPathComponent(self.session.cassetteName).stringByAppendingPathExtension("json")!
+                let outputPath = ((outputDirectory as NSString).stringByAppendingPathComponent(self.session.cassetteName) as NSString).stringByAppendingPathExtension("json")!
                 let data = try NSJSONSerialization.dataWithJSONObject(cassette.dictionary, options: [.PrettyPrinted])
                 data.writeToFile(outputPath, atomically: true)
                 fatalError("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")

--- a/DVR/SessionDownloadTask.swift
+++ b/DVR/SessionDownloadTask.swift
@@ -30,7 +30,7 @@ class SessionDownloadTask: NSURLSessionDownloadTask {
             let location: NSURL?
             if let data = data {
                 // Write data to temporary file
-                let tempURL = NSURL(fileURLWithPath: NSTemporaryDirectory().stringByAppendingPathComponent(NSUUID().UUIDString))
+                let tempURL = NSURL(fileURLWithPath: (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(NSUUID().UUIDString))
                 data.writeToURL(tempURL, atomically: true)
                 location = tempURL
             } else {


### PR DESCRIPTION
Looks like Beta 5 is making working `NSString` and `String` interchangeable harder... Methods operating on `pathComponents` are now available for `String` so it means they need to be casted to `NSString`.

![](http://media3.giphy.com/media/JObgA7952dM9W/giphy.gif)
