### PR TITLE
Compare encoded bodies instead of data when possible Fixes #23

### DIFF
--- a/DVR/Cassette.swift
+++ b/DVR/Cassette.swift
@@ -11,26 +11,26 @@ struct Cassette {
 
     func interactionForRequest(request: NSURLRequest) -> Interaction? {
         for interaction in interactions {
-            let r = interaction.request
-
-            let equivalentBody: Bool
-
-            if let rBody = r.HTTPBody,
-                requestBody = request.HTTPBody,
-                rEncoded = Interaction.encodeBody(rBody, headers: r.allHTTPHeaderFields),
-                requestEncoded = Interaction.encodeBody(requestBody, headers: request.allHTTPHeaderFields) {
-
-                equivalentBody = rEncoded.isEqual(requestEncoded)
-            } else {
-                equivalentBody = r.HTTPBody == request.HTTPBody
-            }
+            let interactionRequest = interaction.request
 
             // Note: We don't check headers right now
-            if r.HTTPMethod == request.HTTPMethod && r.URL == request.URL && equivalentBody {
+            if interactionRequest.HTTPMethod == request.HTTPMethod && interactionRequest.URL == request.URL && equalHTTPBody(request: interactionRequest, request: request) {
                 return interaction
             }
         }
         return nil
+    }
+
+    private func equalHTTPBody(request request1: NSURLRequest, request request2: NSURLRequest) -> Bool {
+        if let body1 = request1.HTTPBody,
+            body2 = request2.HTTPBody,
+            encoded1 = Interaction.encodeBody(body1, headers: request1.allHTTPHeaderFields),
+            encoded2 = Interaction.encodeBody(body2, headers: request2.allHTTPHeaderFields) {
+
+                return encoded1.isEqual(encoded2)
+        } else {
+            return request1.HTTPBody == request2.HTTPBody
+        }
     }
 }
 

--- a/DVR/Cassette.swift
+++ b/DVR/Cassette.swift
@@ -13,8 +13,20 @@ struct Cassette {
         for interaction in interactions {
             let r = interaction.request
 
+            let equivalentBody: Bool
+
+            if let rBody = r.HTTPBody,
+                requestBody = request.HTTPBody,
+                rEncoded = Interaction.encodeBody(rBody, headers: r.allHTTPHeaderFields),
+                requestEncoded = Interaction.encodeBody(requestBody, headers: request.allHTTPHeaderFields) {
+
+                equivalentBody = rEncoded.isEqual(requestEncoded)
+            } else {
+                equivalentBody = r.HTTPBody == request.HTTPBody
+            }
+
             // Note: We don't check headers right now
-            if r.HTTPMethod == request.HTTPMethod && r.URL == request.URL && r.HTTPBody == request.HTTPBody {
+            if r.HTTPMethod == request.HTTPMethod && r.URL == request.URL && equivalentBody {
                 return interaction
             }
         }

--- a/DVR/Cassette.swift
+++ b/DVR/Cassette.swift
@@ -23,26 +23,11 @@ struct Cassette {
             let interactionRequest = interaction.request
 
             // Note: We don't check headers right now
-            if interactionRequest.HTTPMethod == request.HTTPMethod && interactionRequest.URL == request.URL && equalHTTPBody(request: interactionRequest, request: request) {
+            if interactionRequest.HTTPMethod == request.HTTPMethod && interactionRequest.URL == request.URL && interactionRequest.hasHTTPBodyEqualToThatOfRequest(request)  {
                 return interaction
             }
         }
         return nil
-    }
-
-
-    // MARK: - Private
-
-    private func equalHTTPBody(request request1: NSURLRequest, request request2: NSURLRequest) -> Bool {
-        if let body1 = request1.HTTPBody,
-            body2 = request2.HTTPBody,
-            encoded1 = Interaction.encodeBody(body1, headers: request1.allHTTPHeaderFields),
-            encoded2 = Interaction.encodeBody(body2, headers: request2.allHTTPHeaderFields) {
-
-                return encoded1.isEqual(encoded2)
-        } else {
-            return request1.HTTPBody == request2.HTTPBody
-        }
     }
 }
 
@@ -64,6 +49,20 @@ extension Cassette {
             interactions = array.flatMap { Interaction(dictionary: $0) }
         } else {
             interactions = []
+        }
+    }
+}
+
+private extension NSURLRequest {
+    func hasHTTPBodyEqualToThatOfRequest(request: NSURLRequest) -> Bool {
+        if let body1 = self.HTTPBody,
+            body2 = request.HTTPBody,
+            encoded1 = Interaction.encodeBody(body1, headers: self.allHTTPHeaderFields),
+            encoded2 = Interaction.encodeBody(body2, headers: request.allHTTPHeaderFields) {
+
+                return encoded1.isEqual(encoded2)
+        } else {
+            return self.HTTPBody == request.HTTPBody
         }
     }
 }

--- a/DVR/Cassette.swift
+++ b/DVR/Cassette.swift
@@ -1,13 +1,22 @@
 import Foundation
 
 struct Cassette {
+
+    // MARK: - Properties
+
     let name: String
     let interactions: [Interaction]
+
+
+    // MARK: - Initializers
 
     init(name: String, interactions: [Interaction]) {
         self.name = name
         self.interactions = interactions
     }
+
+
+    // MARK: - Functions
 
     func interactionForRequest(request: NSURLRequest) -> Interaction? {
         for interaction in interactions {
@@ -20,6 +29,9 @@ struct Cassette {
         }
         return nil
     }
+
+
+    // MARK: - Private
 
     private func equalHTTPBody(request request1: NSURLRequest, request request2: NSURLRequest) -> Bool {
         if let body1 = request1.HTTPBody,


### PR DESCRIPTION
We now unwrap the `HTTPBody` `NSData`s into and compare using `isEqual`
