### PR TITLE
SessionDataTask's resume does work on a new background thread...

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -35,7 +35,12 @@ class SessionDataTask: NSURLSessionDataTask {
         // Find interaction
         if let interaction = cassette?.interactionForRequest(request) {
             // Forward completion
-            completion?(interaction.responseData, interaction.response, nil)
+            if let completion = completion {
+                let queue = dispatch_queue_create("com.venmo.DVR.sessionDataTaskQueue", nil)
+                dispatch_async(queue) {
+                    completion(interaction.responseData, interaction.response, nil)
+                }
+            }
             return
         }
 

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -12,6 +12,7 @@ class SessionDataTask: NSURLSessionDataTask {
     weak var session: Session!
     let request: NSURLRequest
     let completion: Completion?
+    private let queue = dispatch_queue_create("com.venmo.DVR.sessionDataTaskQueue", nil)
 
 
     // MARK: - Initializers
@@ -36,7 +37,6 @@ class SessionDataTask: NSURLSessionDataTask {
         if let interaction = cassette?.interactionForRequest(request) {
             // Forward completion
             if let completion = completion {
-                let queue = dispatch_queue_create("com.venmo.DVR.sessionDataTaskQueue", nil)
                 dispatch_async(queue) {
                     completion(interaction.responseData, interaction.response, nil)
                 }


### PR DESCRIPTION
as opposed to the calling thread, in order to better mimic NSURLSessionDataTask functionality
