### PR TITLE
Restore print() and abort() behavior

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -37,6 +37,7 @@ class SessionDataTask: NSURLSessionDataTask {
         if let interaction = cassette?.interactionForRequest(request) {
             // Forward completion
             if let completion = completion {
+                print("[DVR] Replaying '\(session.cassetteName)'")
                 dispatch_async(queue) {
                     completion(interaction.responseData, interaction.response, nil)
                 }
@@ -45,12 +46,14 @@ class SessionDataTask: NSURLSessionDataTask {
         }
 
 		if cassette != nil {
-			fatalError("[DVR] Invalid request. The request was not found in the cassette.")
+			print("[DVR] Invalid request. The request was not found in the cassette.")
+            abort()
 		}
 
         // Cassette is missing. Record.
 		if session.recordingEnabled == false {
-			fatalError("[DVR] Recording is disabled.")
+			print("[DVR] Recording is disabled.")
+            abort()
 		}
 
         // Create directory
@@ -66,7 +69,8 @@ class SessionDataTask: NSURLSessionDataTask {
             
             //Ensure we have a response
             guard let response = response else {
-                fatalError("[DVR] Failed to persist cassette, because the task returned a nil response.")
+                print("[DVR] Failed to persist cassette, because the task returned a nil response.")
+                abort()
             }
             
             // Create cassette
@@ -80,21 +84,25 @@ class SessionDataTask: NSURLSessionDataTask {
 
                 // Add trailing new line
                 guard var string = NSString(data: data, encoding: NSUTF8StringEncoding) else {
-                    fatalError("[DVR] Failed to persist cassette.")
+                    print("[DVR] Failed to persist cassette.")
+                    abort()
                 }
                 string = string.stringByAppendingString("\n")
 
                 if let data = string.dataUsingEncoding(NSUTF8StringEncoding) {
                     data.writeToFile(outputPath, atomically: true)
-                    fatalError("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")
+                    print("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")
+                    abort()
                 }
 
-                fatalError("[DVR] Failed to persist cassette.")
+                print("[DVR] Failed to persist cassette.")
+                abort()
             } catch {
                 // Do nothing
             }
 
-			fatalError("[DVR] Failed to persist cassette.")
+			print("[DVR] Failed to persist cassette.")
+            abort()
         }
         task.resume()
     }

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -45,16 +45,16 @@ class SessionDataTask: NSURLSessionDataTask {
             return
         }
 
-		if cassette != nil {
+        if cassette != nil {
             print("[DVR] Invalid request. The request was not found in the cassette.")
             abort()
-		}
+        }
 
         // Cassette is missing. Record.
-		if session.recordingEnabled == false {
+        if session.recordingEnabled == false {
             print("[DVR] Recording is disabled.")
             abort()
-		}
+        }
 
         // Create directory
         let outputDirectory = (session.outputDirectory as NSString).stringByExpandingTildeInPath

--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -46,13 +46,13 @@ class SessionDataTask: NSURLSessionDataTask {
         }
 
 		if cassette != nil {
-			print("[DVR] Invalid request. The request was not found in the cassette.")
+            print("[DVR] Invalid request. The request was not found in the cassette.")
             abort()
 		}
 
         // Cassette is missing. Record.
 		if session.recordingEnabled == false {
-			print("[DVR] Recording is disabled.")
+            print("[DVR] Recording is disabled.")
             abort()
 		}
 
@@ -101,7 +101,7 @@ class SessionDataTask: NSURLSessionDataTask {
                 // Do nothing
             }
 
-			print("[DVR] Failed to persist cassette.")
+            print("[DVR] Failed to persist cassette.")
             abort()
         }
         task.resume()


### PR DESCRIPTION
See my comments on this commit https://github.com/venmo/DVR/commit/ecabe603c5b01bcb9f84ad8465e1a2f6d118fc75 which replaced `print` and `abort` with `fatalError`.
