### PR TITLE
Fix warnings emitted by the test targets

### DIFF
--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		3647AFB31B335D5500EF10D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.iostests;
@@ -561,6 +562,7 @@
 		3647AFB41B335D5500EF10D4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.iostests;
@@ -609,6 +611,7 @@
 		3690A0901B33AA3C00731222 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -621,6 +624,7 @@
 		3690A0911B33AA3C00731222 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DVR/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/DVR/Session.swift
+++ b/DVR/Session.swift
@@ -143,6 +143,10 @@ public class Session: NSURLSession {
     }
 
     private func persist(interactions: [Interaction]) {
+        defer {
+            abort()
+        }
+
         // Create directory
         let outputDirectory = (self.outputDirectory as NSString).stringByExpandingTildeInPath
         let fileManager = NSFileManager.defaultManager()
@@ -151,13 +155,14 @@ public class Session: NSURLSession {
 				try fileManager.createDirectoryAtPath(outputDirectory, withIntermediateDirectories: true, attributes: nil)
 			} catch {
 				print("[DVR] Failed to create cassettes directory.")
-				abort()
 			}
         }
 
         let cassette = Cassette(name: cassetteName, interactions: interactions)
 
         // Persist
+
+
         do {
             let outputPath = ((outputDirectory as NSString).stringByAppendingPathComponent(cassetteName) as NSString).stringByAppendingPathExtension("json")!
             let data = try NSJSONSerialization.dataWithJSONObject(cassette.dictionary, options: [.PrettyPrinted])
@@ -165,21 +170,18 @@ public class Session: NSURLSession {
             // Add trailing new line
             guard var string = NSString(data: data, encoding: NSUTF8StringEncoding) else {
                 print("[DVR] Failed to persist cassette.")
-                abort()
+                return
             }
             string = string.stringByAppendingString("\n")
 
             if let data = string.dataUsingEncoding(NSUTF8StringEncoding) {
                 data.writeToFile(outputPath, atomically: true)
                 print("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")
-                abort()
             }
 
             print("[DVR] Failed to persist cassette.")
-            abort()
         } catch {
             print("[DVR] Failed to persist cassette.")
-            abort()
         }
     }
 


### PR DESCRIPTION
- Fix an issue where there were warnings about using non-extension safe API in the test targets.
- Restructure the persist method to silence a warning about unreachable code. Previously, the final `abort()` in the `do` block was unreachable from the tests. Now using a `defer` to abort before the method returns.
