### PR TITLE
Session delegate (Alamofire) support - closes #11, closes #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+.DS_Store
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build

--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -119,7 +119,9 @@
 				3647AF9D1B335D5500EF10D4 /* DVR */,
 				3647AF9C1B335D5500EF10D4 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		3647AF9C1B335D5500EF10D4 /* Products */ = {
 			isa = PBXGroup;

--- a/DVR/Session.swift
+++ b/DVR/Session.swift
@@ -17,7 +17,7 @@ public class Session: NSURLSession {
     private var completedInteractions = [Interaction]()
     private var completionBlock: (Void -> Void)?
 
-    private var nextTaskID: Int = 0
+    private static var nextTaskID: Int = 0
     private let idGenerationQueue = dispatch_queue_create("com.venmo.DVR.idGenerationQueue", nil)
 
     private let _delegate: NSURLSessionDelegate?
@@ -126,8 +126,8 @@ public class Session: NSURLSession {
     private func generateNextTaskID() -> Int {
         var id: Int!
         dispatch_sync(idGenerationQueue) {
-            id = self.nextTaskID
-            self.nextTaskID += 1
+            id = Session.nextTaskID
+            Session.nextTaskID += 1
         }
         return id
     }

--- a/DVR/SessionDownloadTask.swift
+++ b/DVR/SessionDownloadTask.swift
@@ -10,13 +10,38 @@ class SessionDownloadTask: NSURLSessionDownloadTask {
     let request: NSURLRequest
     let completion: Completion?
 
+    // MARK: - Overridden Properties
+
+    let _taskIdentifier: Int
+    override var taskIdentifier: Int {
+        return _taskIdentifier
+    }
+
+    override var originalRequest: NSURLRequest? {
+        return request
+    }
+
+    override var currentRequest: NSURLRequest? {
+        return request
+    }
+
+    var _response: NSURLResponse? = nil
+    override var response: NSURLResponse? {
+        return _response
+    }
+
+    var _state: NSURLSessionTaskState = .Suspended
+    override var state: NSURLSessionTaskState {
+        return _state
+    }
 
     // MARK: - Initializers
 
-    init(session: Session, request: NSURLRequest, completion: Completion? = nil) {
+    init(taskIdentifier: Int, session: Session, request: NSURLRequest, completion: Completion? = nil) {
         self.session = session
         self.request = request
         self.completion = completion
+        _taskIdentifier = taskIdentifier
     }
 
     // MARK: - NSURLSessionTask
@@ -26,19 +51,27 @@ class SessionDownloadTask: NSURLSessionDownloadTask {
     }
 
     override func resume() {
-        let task = SessionDataTask(session: session, request: request) { data, response, error in
+        var task: SessionDataTask! = nil
+        task = SessionDataTask(taskIdentifier: taskIdentifier, session: session, request: request) { data, response, error in
             let location: NSURL?
             if let data = data {
                 // Write data to temporary file
                 let tempURL = NSURL(fileURLWithPath: (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(NSUUID().UUIDString))
                 data.writeToURL(tempURL, atomically: true)
                 location = tempURL
+
+                // Notify the delegate
+                if let delegate = task.session.delegate as? NSURLSessionDownloadDelegate {
+                    delegate.URLSession(task.session, downloadTask: self, didFinishDownloadingToURL: tempURL)
+                }
             } else {
                 location = nil
             }
 
             self.completion?(location, response, error)
+            task._state = .Running
         }
         task.resume()
+        task._state = .Running
     }
 }


### PR DESCRIPTION
- Adds support for data task delegate
- Adds support for download task delegate
- Adds .gitignore
- Sets 4 space tab setting on project file

This enables DVR to work with Alamofire.

``` swift
let delegate = Manager.SessionDelegate()
let session = Session(cassetteName: "example", delegate: delegate)
let manager = Manager(session: session, delegate: delegate)
```
