### PR TITLE
Replace print() + abort() with fatalError() so Quick Testing Framework correctly handles error

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -52,27 +52,23 @@ class SessionDataTask: NSURLSessionDataTask {
         }
 
         if cassette != nil {
-            print("[DVR] Invalid request. The request was not found in the cassette.")
-            abort()
+            fatalError("[DVR] Invalid request. The request was not found in the cassette.")
         }
 
         // Cassette is missing. Record.
         if session.recordingEnabled == false {
-            print("[DVR] Recording is disabled.")
-            abort()
+            fatalError("[DVR] Recording is disabled.")
         }
 
         let task = session.backingSession.dataTaskWithRequest(request) { [weak self] data, response, error in
 
             //Ensure we have a response
             guard let response = response else {
-                print("[DVR] Failed to record because the task returned a nil response.")
-                abort()
+                fatalError("[DVR] Failed to record because the task returned a nil response.")
             }
 
             guard let this = self else {
-                print("[DVR] Something has gone horribly wrong.")
-                abort()
+                fatalError("[DVR] Something has gone horribly wrong.")
             }
 
             // Still call the completion block so the user can chain requests while recording.


### PR DESCRIPTION
This helps the developer catch the error that the interaction is not found when testing using Quick Framework
