### PR TITLE
Expose currentRequest in SessionDataTask

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -19,6 +19,10 @@ final class SessionDataTask: URLSessionDataTask {
         return interaction?.response
     }
 
+    override var currentRequest: URLRequest? {
+        return request
+    }
+
 
     // MARK: - Initializers
 

--- a/DVR/Tests/SessionTests.swift
+++ b/DVR/Tests/SessionTests.swift
@@ -26,6 +26,13 @@ class SessionTests: XCTestCase {
         } else {
             XCTFail()
         }
+
+        if let req = dataTask.currentRequest, let url = req.url {
+            XCTAssert(req.httpMethod == "GET")
+            XCTAssert(url.absoluteString == "http://example.com")
+        } else {
+            XCTFail()
+        }
     }
 
     func testDataTaskWithCompletion() {


### PR DESCRIPTION
Exposes currentRequest member variable of SessionDataTask in extended SessionDataTask. I'm fairly new to swift so any critiques are very welcome.