### PR TITLE
Expose tvOS support for CocoaPods

### DIFF
--- a/DVR.podspec
+++ b/DVR.podspec
@@ -17,6 +17,7 @@ DVR.Session is a subclass of NSURLSession so you can use it as a drop in replace
                          tag: "v#{s.version}" }
 
   s.ios.deployment_target = '8.0'
+  s.tvos.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
 
   s.source_files = 'DVR/*.{swift}'


### PR DESCRIPTION
Had to bump the version to `9.0` since Swift isn't allowed for `8.0` on Apple TV.

Fixes #56