### PR TITLE
Fix Interaction to record HTTP headers and status codes

### DIFF
--- a/DVR/Interaction.swift
+++ b/DVR/Interaction.swift
@@ -83,7 +83,7 @@ extension Interaction {
 
         var responseDictionary = self.response.dictionary
 
-        if let httpResponse = response as? HTTPURLResponse {
+        if let httpResponse = response as? Foundation.HTTPURLResponse {
             responseDictionary["headers"] = httpResponse.allHeaderFields
             responseDictionary["status"] = httpResponse.statusCode
         }


### PR DESCRIPTION
I just started using this library today, but I think I hit a small bug in `Interaction`: I was unable to save the status code and response headers when recording. Here's what I found:

When finished recording, `Session.persist` calls down to `Interaction.dictionary`, which checks if `response` is a `HTTPURLResponse`. If it is, it records the headers and status code for the response:

```swift
if let httpResponse = response as? HTTPURLResponse { …
```

 However, this is checking if the response is a `DVR.HTTPURLResponse`, not a `Foundation.HTTPURLResponse`. Since `DVR.HTTPURLResponse` is only get initialized from cassette dictionaries, this condition should never be true.

I changed `HTTPURLResponse` to `Foundation.HTTPURLResponse` and was able to record status code / headers successfully.


### Testing
Confirmed that this doesn't affect existing tests.