### PR TITLE
Debug status code not being recorded

### DIFF
--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -65,6 +65,30 @@
 		ED7862B11F7D44EB00CB2625 /* text.json in Resources */ = {isa = PBXBuildFile; fileRef = ED7862961F7D44E200CB2625 /* text.json */; };
 		ED7862B21F7D44EB00CB2625 /* upload-data.json in Resources */ = {isa = PBXBuildFile; fileRef = ED7862941F7D44E200CB2625 /* upload-data.json */; };
 		ED7862B31F7D44EB00CB2625 /* upload-file.json in Resources */ = {isa = PBXBuildFile; fileRef = ED7862931F7D44E200CB2625 /* upload-file.json */; };
+		EDC4065920D9ABE900A5D1F7 /* upload-file.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065120D9ABE800A5D1F7 /* upload-file.json */; };
+		EDC4065A20D9ABE900A5D1F7 /* upload-file.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065120D9ABE800A5D1F7 /* upload-file.json */; };
+		EDC4065B20D9ABE900A5D1F7 /* upload-file.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065120D9ABE800A5D1F7 /* upload-file.json */; };
+		EDC4065C20D9ABE900A5D1F7 /* failed-request-example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065220D9ABE800A5D1F7 /* failed-request-example.json */; };
+		EDC4065D20D9ABE900A5D1F7 /* failed-request-example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065220D9ABE800A5D1F7 /* failed-request-example.json */; };
+		EDC4065E20D9ABE900A5D1F7 /* failed-request-example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065220D9ABE800A5D1F7 /* failed-request-example.json */; };
+		EDC4065F20D9ABE900A5D1F7 /* multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065320D9ABE800A5D1F7 /* multiple.json */; };
+		EDC4066020D9ABE900A5D1F7 /* multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065320D9ABE800A5D1F7 /* multiple.json */; };
+		EDC4066120D9ABE900A5D1F7 /* multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065320D9ABE800A5D1F7 /* multiple.json */; };
+		EDC4066220D9ABE900A5D1F7 /* example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065420D9ABE800A5D1F7 /* example.json */; };
+		EDC4066320D9ABE900A5D1F7 /* example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065420D9ABE800A5D1F7 /* example.json */; };
+		EDC4066420D9ABE900A5D1F7 /* example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065420D9ABE800A5D1F7 /* example.json */; };
+		EDC4066520D9ABE900A5D1F7 /* json-example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065520D9ABE800A5D1F7 /* json-example.json */; };
+		EDC4066620D9ABE900A5D1F7 /* json-example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065520D9ABE800A5D1F7 /* json-example.json */; };
+		EDC4066720D9ABE900A5D1F7 /* json-example.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065520D9ABE800A5D1F7 /* json-example.json */; };
+		EDC4066820D9ABE900A5D1F7 /* testfile.txt in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065620D9ABE800A5D1F7 /* testfile.txt */; };
+		EDC4066920D9ABE900A5D1F7 /* testfile.txt in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065620D9ABE800A5D1F7 /* testfile.txt */; };
+		EDC4066A20D9ABE900A5D1F7 /* testfile.txt in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065620D9ABE800A5D1F7 /* testfile.txt */; };
+		EDC4066B20D9ABE900A5D1F7 /* text.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065720D9ABE800A5D1F7 /* text.json */; };
+		EDC4066C20D9ABE900A5D1F7 /* text.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065720D9ABE800A5D1F7 /* text.json */; };
+		EDC4066D20D9ABE900A5D1F7 /* text.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065720D9ABE800A5D1F7 /* text.json */; };
+		EDC4066E20D9ABE900A5D1F7 /* upload-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065820D9ABE800A5D1F7 /* upload-data.json */; };
+		EDC4066F20D9ABE900A5D1F7 /* upload-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065820D9ABE800A5D1F7 /* upload-data.json */; };
+		EDC4067020D9ABE900A5D1F7 /* upload-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EDC4065820D9ABE800A5D1F7 /* upload-data.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,6 +143,14 @@
 		ED7862951F7D44E200CB2625 /* multiple.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = multiple.json; sourceTree = "<group>"; };
 		ED7862961F7D44E200CB2625 /* text.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = text.json; sourceTree = "<group>"; };
 		ED7862971F7D44E200CB2625 /* json-example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "json-example.json"; sourceTree = "<group>"; };
+		EDC4065120D9ABE800A5D1F7 /* upload-file.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "upload-file.json"; sourceTree = "<group>"; };
+		EDC4065220D9ABE800A5D1F7 /* failed-request-example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "failed-request-example.json"; sourceTree = "<group>"; };
+		EDC4065320D9ABE800A5D1F7 /* multiple.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = multiple.json; sourceTree = "<group>"; };
+		EDC4065420D9ABE800A5D1F7 /* example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = example.json; sourceTree = "<group>"; };
+		EDC4065520D9ABE800A5D1F7 /* json-example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "json-example.json"; sourceTree = "<group>"; };
+		EDC4065620D9ABE800A5D1F7 /* testfile.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testfile.txt; sourceTree = "<group>"; };
+		EDC4065720D9ABE800A5D1F7 /* text.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = text.json; sourceTree = "<group>"; };
+		EDC4065820D9ABE800A5D1F7 /* upload-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "upload-data.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -245,6 +277,7 @@
 		ED7862901F7D44D100CB2625 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				EDC4065020D9ABE800A5D1F7 /* Fixtures */,
 				ED7862911F7D44E200CB2625 /* example.json */,
 				ED7862971F7D44E200CB2625 /* json-example.json */,
 				ED7862951F7D44E200CB2625 /* multiple.json */,
@@ -254,6 +287,21 @@
 				ED7862931F7D44E200CB2625 /* upload-file.json */,
 			);
 			path = Fixtures;
+			sourceTree = "<group>";
+		};
+		EDC4065020D9ABE800A5D1F7 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				EDC4065120D9ABE800A5D1F7 /* upload-file.json */,
+				EDC4065220D9ABE800A5D1F7 /* failed-request-example.json */,
+				EDC4065320D9ABE800A5D1F7 /* multiple.json */,
+				EDC4065420D9ABE800A5D1F7 /* example.json */,
+				EDC4065520D9ABE800A5D1F7 /* json-example.json */,
+				EDC4065620D9ABE800A5D1F7 /* testfile.txt */,
+				EDC4065720D9ABE800A5D1F7 /* text.json */,
+				EDC4065820D9ABE800A5D1F7 /* upload-data.json */,
+			);
+			name = Fixtures;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -464,13 +512,21 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDC4066720D9ABE900A5D1F7 /* json-example.json in Resources */,
 				ED7862AE1F7D44EB00CB2625 /* json-example.json in Resources */,
+				EDC4066D20D9ABE900A5D1F7 /* text.json in Resources */,
 				ED7862AD1F7D44EB00CB2625 /* example.json in Resources */,
+				EDC4065B20D9ABE900A5D1F7 /* upload-file.json in Resources */,
+				EDC4066A20D9ABE900A5D1F7 /* testfile.txt in Resources */,
 				ED7862B21F7D44EB00CB2625 /* upload-data.json in Resources */,
 				ED7862B31F7D44EB00CB2625 /* upload-file.json in Resources */,
+				EDC4066420D9ABE900A5D1F7 /* example.json in Resources */,
+				EDC4066120D9ABE900A5D1F7 /* multiple.json in Resources */,
 				ED7862B11F7D44EB00CB2625 /* text.json in Resources */,
+				EDC4067020D9ABE900A5D1F7 /* upload-data.json in Resources */,
 				ED7862B01F7D44EB00CB2625 /* testfile.txt in Resources */,
 				ED7862AF1F7D44EB00CB2625 /* multiple.json in Resources */,
+				EDC4065E20D9ABE900A5D1F7 /* failed-request-example.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -486,13 +542,21 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDC4066520D9ABE900A5D1F7 /* json-example.json in Resources */,
 				ED7862A01F7D44EA00CB2625 /* json-example.json in Resources */,
+				EDC4066B20D9ABE900A5D1F7 /* text.json in Resources */,
 				ED78629F1F7D44EA00CB2625 /* example.json in Resources */,
+				EDC4065920D9ABE900A5D1F7 /* upload-file.json in Resources */,
+				EDC4066820D9ABE900A5D1F7 /* testfile.txt in Resources */,
 				ED7862A41F7D44EA00CB2625 /* upload-data.json in Resources */,
 				ED7862A51F7D44EA00CB2625 /* upload-file.json in Resources */,
+				EDC4066220D9ABE900A5D1F7 /* example.json in Resources */,
+				EDC4065F20D9ABE900A5D1F7 /* multiple.json in Resources */,
 				ED7862A31F7D44EA00CB2625 /* text.json in Resources */,
+				EDC4066E20D9ABE900A5D1F7 /* upload-data.json in Resources */,
 				ED7862A21F7D44EA00CB2625 /* testfile.txt in Resources */,
 				ED7862A11F7D44EA00CB2625 /* multiple.json in Resources */,
+				EDC4065C20D9ABE900A5D1F7 /* failed-request-example.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -507,13 +571,21 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDC4066620D9ABE900A5D1F7 /* json-example.json in Resources */,
 				ED7862A71F7D44EB00CB2625 /* json-example.json in Resources */,
+				EDC4066C20D9ABE900A5D1F7 /* text.json in Resources */,
 				ED7862A61F7D44EB00CB2625 /* example.json in Resources */,
+				EDC4065A20D9ABE900A5D1F7 /* upload-file.json in Resources */,
+				EDC4066920D9ABE900A5D1F7 /* testfile.txt in Resources */,
 				ED7862AB1F7D44EB00CB2625 /* upload-data.json in Resources */,
 				ED7862AC1F7D44EB00CB2625 /* upload-file.json in Resources */,
+				EDC4066320D9ABE900A5D1F7 /* example.json in Resources */,
+				EDC4066020D9ABE900A5D1F7 /* multiple.json in Resources */,
 				ED7862AA1F7D44EB00CB2625 /* text.json in Resources */,
+				EDC4066F20D9ABE900A5D1F7 /* upload-data.json in Resources */,
 				ED7862A91F7D44EB00CB2625 /* testfile.txt in Resources */,
 				ED7862A81F7D44EB00CB2625 /* multiple.json in Resources */,
+				EDC4065D20D9ABE900A5D1F7 /* failed-request-example.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DVR/Tests/Fixtures/failed-request-example.json
+++ b/DVR/Tests/Fixtures/failed-request-example.json
@@ -1,0 +1,41 @@
+{
+  "interactions" : [
+    {
+      "response" : {
+        "status" : 401,
+        "headers" : {
+          "Date" : "Tue, 12 Jun 2018 15:55:49 GMT",
+          "Content-Length" : "265",
+          "Age" : "225",
+          "Access-Control-Expose-Headers" : "Etag",
+          "Access-Control-Max-Age" : "86400",
+          "Etag" : "\"9906052eabccd1a6c0331807805000e3\"",
+          "Access-Control-Allow-Headers" : "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+          "Accept-Ranges" : "bytes",
+          "Vary" : "Accept-Encoding",
+          "X-Cache-Hits" : "1",
+          "X-Cache" : "HIT",
+          "Content-Type" : "application\/vnd.contentful.delivery.v1+json",
+          "Access-Control-Allow-Methods" : "GET,HEAD,OPTIONS",
+          "Connection" : "keep-alive",
+          "X-Contentful-Request-Id" : "72b236f9b6493cdbdadad8a16c54254b",
+          "X-Content-Type-Options" : "nosniff",
+          "X-Timer" : "S1528818949.158502,VS0,VE0",
+          "X-Served-By" : "cache-hhn1536-HHN",
+          "Access-Control-Allow-Origin" : "*",
+          "Server" : "Contentful",
+          "Cache-Control" : "max-age=0",
+          "Via" : "1.1 varnish"
+        },
+        "body" : "ewogICJzeXMiOiB7CiAgICAidHlwZSI6ICJFcnJvciIsCiAgICAiaWQiOiAiQWNjZXNzVG9rZW5JbnZhbGlkIgogIH0sCiAgIm1lc3NhZ2UiOiAiQW4gYWNjZXNzIHRva2VuIGlzIHJlcXVpcmVkLiBQbGVhc2Ugc2VuZCBvbmUgdGhyb3VnaCB0aGUgSFRUUCBBdXRob3JpemF0aW9uIGhlYWRlciBvciBhcyB0aGUgcXVlcnkgcGFyYW1ldGVyIFwiYWNjZXNzX3Rva2VuXCIuIiwKICAicmVxdWVzdElkIjogIjcyYjIzNmY5YjY0OTNjZGJkYWRhZDhhMTZjNTQyNTRiIgp9Cg==",
+        "url" : "http:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/entries"
+      },
+      "recorded_at" : 1528818949.1677389,
+      "request" : {
+        "method" : "GET",
+        "url" : "http:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/entries"
+      }
+    }
+  ],
+  "name" : "failed-request-example"
+}

--- a/Tests/DVRTests/Fixtures/failed-request-example.json
+++ b/Tests/DVRTests/Fixtures/failed-request-example.json
@@ -1,0 +1,42 @@
+{
+  "interactions" : [
+    {
+      "response" : {
+        "status" : 401,
+        "headers" : {
+          "Date" : "Tue, 19 Jun 2018 21:21:50 GMT",
+          "Content-Length" : "265",
+          "Age" : "0",
+          "Access-Control-Expose-Headers" : "Etag",
+          "Access-Control-Max-Age" : "86400",
+          "Contentful-Api" : "cda_cached",
+          "Etag" : "\"1bda5990e6a6273376adc4f95ae5712a\"",
+          "Access-Control-Allow-Headers" : "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+          "Accept-Ranges" : "bytes",
+          "Vary" : "Accept-Encoding",
+          "X-Cache-Hits" : "0",
+          "X-Cache" : "MISS",
+          "Content-Type" : "application\/vnd.contentful.delivery.v1+json",
+          "Access-Control-Allow-Methods" : "GET,HEAD,OPTIONS",
+          "Connection" : "keep-alive",
+          "X-Contentful-Request-Id" : "99f56d6421f76c5b025bcdc91bf044b3",
+          "X-Content-Type-Options" : "nosniff",
+          "X-Timer" : "S1529443310.140883,VS0,VE112",
+          "X-Served-By" : "cache-ams4437-AMS",
+          "Access-Control-Allow-Origin" : "*",
+          "Server" : "Contentful",
+          "Cache-Control" : "max-age=0",
+          "Via" : "1.1 varnish"
+        },
+        "body" : "ewogICJzeXMiOiB7CiAgICAidHlwZSI6ICJFcnJvciIsCiAgICAiaWQiOiAiQWNjZXNzVG9rZW5JbnZhbGlkIgogIH0sCiAgIm1lc3NhZ2UiOiAiQW4gYWNjZXNzIHRva2VuIGlzIHJlcXVpcmVkLiBQbGVhc2Ugc2VuZCBvbmUgdGhyb3VnaCB0aGUgSFRUUCBBdXRob3JpemF0aW9uIGhlYWRlciBvciBhcyB0aGUgcXVlcnkgcGFyYW1ldGVyIFwiYWNjZXNzX3Rva2VuXCIuIiwKICAicmVxdWVzdElkIjogIjk5ZjU2ZDY0MjFmNzZjNWIwMjViY2RjOTFiZjA0NGIzIgp9Cg==",
+        "url" : "http:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/entries"
+      },
+      "recorded_at" : 1529443310.3058901,
+      "request" : {
+        "method" : "GET",
+        "url" : "http:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/entries"
+      }
+    }
+  ],
+  "name" : "failed-request-example"
+}

--- a/Tests/DVRTests/SessionTests.swift
+++ b/Tests/DVRTests/SessionTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import DVR
 
 class SessionTests: XCTestCase {
@@ -183,6 +184,25 @@ class SessionTests: XCTestCase {
         session.recordingEnabled = false
 
         let task = session.dataTask(with: request)
+        task.resume()
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testRecordingStatusCodeForFailedRequest() {
+        let expectation = self.expectation(description: "didCompleteWithError")
+
+        let request = URLRequest(url: URL(string: "http://cdn.contentful.com/spaces/cfexampleapi/entries")!)
+
+        let config = URLSessionConfiguration.default
+        let backingSession = URLSession(configuration: config)
+        let session = Session(cassetteName: "failed-request-example", backingSession: backingSession)
+
+        let task = session.dataTask(with: request) { (_, urlResponse, _) in
+            XCTAssertNotEqual(200, (urlResponse as? Foundation.HTTPURLResponse)?.statusCode)
+            XCTAssertEqual(401, (urlResponse as? Foundation.HTTPURLResponse)?.statusCode)
+            expectation.fulfill()
+        }
         task.resume()
 
         waitForExpectations(timeout: 1, handler: nil)


### PR DESCRIPTION
Fixes #74 & #69 

This PR fixes a regression that caused the http status code and http headers to not be recorded in the case of non-200 responses. I've added a test to avoid future regressions.