### PR TITLE
Add travis job for tvOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode9.4
 xcode_project: DVR.xcodeproj
 
 matrix:
@@ -7,11 +7,15 @@ matrix:
     - xcode_scheme: DVR-iOS
       xcode_sdk: iphonesimulator
       env:
-        - DESTINATION="iOS Simulator,OS=11.3,name=iPhone X"
+        - DESTINATION="iOS Simulator,OS=11.4,name=iPhone X"
     - xcode_scheme: DVR-macOS
       xcode_sdk: macosx
       env:
         - DESTINATION="macOS,arch=x86_64"
+    - xcode_scheme: DVR-tvOS
+      xcode_sdk: appletvsimulator
+      env:
+        - DESTINATION="tvOS Simulator,name=Apple TV 4K,OS=11.4"
     - env:
       - SWIFT_BUILD=true
 


### PR DESCRIPTION
To ensure stability on tvOS

I investigated to see if travis had any predefined variable names for the destination (i.e. simulators) so that we could remove the yml lines that set environment variables, but I'm quite sure now they don't have anything—if they do, it's for sure not documented. See relevant discussion [here](https://github.com/venmo/DVR/pull/73#discussion_r196141455)