### PR TITLE
Forward delegateQueue through to the backing session

### DIFF
--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -25,6 +25,10 @@ open class Session: URLSession {
         return backingSession.delegate
     }
 
+    open override var delegateQueue: OperationQueue {
+        return backingSession.delegateQueue
+    }
+
     // MARK: - Initializers
 
     public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: Bundle = Session.defaultTestBundle!, backingSession: URLSession = URLSession.shared) {


### PR DESCRIPTION
Alamofire accesses `.delegateQueue` (to verify that it is configured in the way that Alamofire expects).