### PR TITLE
Fix "[Session defaultTaskGroup]: unrecognized selector sent to instance" for Swift 5.1 (#93)

### DIFF
--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -37,6 +37,14 @@ open class Session: URLSession {
 
 
     // MARK: - URLSession
+    
+    open override func dataTask(with url: URL) -> URLSessionDataTask {
+        return addDataTask(URLRequest(url: url))
+    }
+
+    open override func dataTask(with url: URL, completionHandler: @escaping ((Data?, Foundation.URLResponse?, Error?) -> Void)) -> URLSessionDataTask {
+        return addDataTask(URLRequest(url: url), completionHandler: completionHandler)
+    }
 
     open override func dataTask(with request: URLRequest) -> URLSessionDataTask {
         return addDataTask(request)

--- a/Tests/DVRTests/SessionTests.swift
+++ b/Tests/DVRTests/SessionTests.swift
@@ -41,6 +41,32 @@ class SessionTests: XCTestCase {
             XCTFail()
         }
     }
+    
+    func testDataTaskWithUrl() {
+        let url = URL(string: "http://example.com")!
+        let dataTask = session.dataTask(with: url)
+        
+        XCTAssert(dataTask is SessionDataTask)
+        
+        if let dataTask = dataTask as? SessionDataTask, let headers = dataTask.request.allHTTPHeaderFields {
+            XCTAssert(headers["testSessionHeader"] == "testSessionHeaderValue")
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testDataTaskWithUrlAndCompletion() {
+        let url = URL(string: "http://example.com")!
+        let dataTask = session.dataTask(with: url, completionHandler: { _, _, _ in return })
+        
+        XCTAssert(dataTask is SessionDataTask)
+        
+        if let dataTask = dataTask as? SessionDataTask, let headers = dataTask.request.allHTTPHeaderFields {
+            XCTAssert(headers["testSessionHeader"] == "testSessionHeaderValue")
+        } else {
+            XCTFail()
+        }
+    }
 
     func testPlayback() {
         session.recordingEnabled = false


### PR DESCRIPTION
Fix dataTask with URL for Swift 5.1 (#93 ).