### PR TITLE
Expose currentRequest in SessionDataTask

### DIFF
--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -19,6 +19,10 @@ final class SessionDataTask: URLSessionDataTask {
         return interaction?.response
     }
 
+    override var currentRequest: URLRequest? {
+        return request
+    }
+
 
     // MARK: - Initializers
 

--- a/Tests/DVRTests/SessionTests.swift
+++ b/Tests/DVRTests/SessionTests.swift
@@ -27,6 +27,8 @@ class SessionTests: XCTestCase {
         } else {
             XCTFail()
         }
+
+        XCTAssertEqual(dataTask.currentRequest?.url?.absoluteString, request.url?.absoluteString)
     }
 
     func testDataTaskWithCompletion() {


### PR DESCRIPTION
Based on Prior PR which went stale (due to limited maintenance)
https://github.com/venmo/DVR/pull/70 by https://github.com/ocurr

Goal:
Expose currentRequest which should be expected given URLSessionDataTask subclass

Reasoning:
By exposing currentTask,  SessionDataTask can provide request for easy logging support

Changes:
- Provide currentRequest override + test