### PR TITLE
Select response based on request headers

### DIFF
--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -56,6 +56,9 @@
 		BB9465A2224BC2620004F29B /* failed-request-example.json in Resources */ = {isa = PBXBuildFile; fileRef = BB9465A1224BC2620004F29B /* failed-request-example.json */; };
 		BB9465A3224BC2620004F29B /* failed-request-example.json in Resources */ = {isa = PBXBuildFile; fileRef = BB9465A1224BC2620004F29B /* failed-request-example.json */; };
 		BB9465A4224BC2620004F29B /* failed-request-example.json in Resources */ = {isa = PBXBuildFile; fileRef = BB9465A1224BC2620004F29B /* failed-request-example.json */; };
+		DB256BA92666AEBB006689A9 /* different-headers.json in Resources */ = {isa = PBXBuildFile; fileRef = DB256BA82666AEBB006689A9 /* different-headers.json */; };
+		DB256BAA2666AEBB006689A9 /* different-headers.json in Resources */ = {isa = PBXBuildFile; fileRef = DB256BA82666AEBB006689A9 /* different-headers.json */; };
+		DB256BAB2666AEBB006689A9 /* different-headers.json in Resources */ = {isa = PBXBuildFile; fileRef = DB256BA82666AEBB006689A9 /* different-headers.json */; };
 		ED7862871F7D42C200CB2625 /* SessionUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7862821F7D42B800CB2625 /* SessionUploadTests.swift */; };
 		ED7862881F7D42C200CB2625 /* SessionUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7862821F7D42B800CB2625 /* SessionUploadTests.swift */; };
 		ED7862891F7D42C300CB2625 /* SessionUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7862821F7D42B800CB2625 /* SessionUploadTests.swift */; };
@@ -113,6 +116,7 @@
 		3690A0841B33AA3C00731222 /* DVRTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DVRTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B19D62641CB1860400E16D11 /* SessionUploadTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionUploadTask.swift; sourceTree = "<group>"; };
 		BB9465A1224BC2620004F29B /* failed-request-example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "failed-request-example.json"; sourceTree = "<group>"; };
+		DB256BA82666AEBB006689A9 /* different-headers.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "different-headers.json"; sourceTree = "<group>"; };
 		ED78627F1F7D42B700CB2625 /* SessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTests.swift; sourceTree = "<group>"; };
 		ED7862811F7D42B800CB2625 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ED7862821F7D42B800CB2625 /* SessionUploadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionUploadTests.swift; sourceTree = "<group>"; };
@@ -259,6 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				ED7862911F7D44E200CB2625 /* example.json */,
+				DB256BA82666AEBB006689A9 /* different-headers.json */,
 				BB9465A1224BC2620004F29B /* failed-request-example.json */,
 				ED7862971F7D44E200CB2625 /* json-example.json */,
 				ED7862951F7D44E200CB2625 /* multiple.json */,
@@ -484,6 +489,7 @@
 				BB94659A224BBCEB0004F29B /* json-example.json in Resources */,
 				BB94659B224BBCEB0004F29B /* multiple.json in Resources */,
 				BB94659D224BBCEB0004F29B /* text.json in Resources */,
+				DB256BAB2666AEBB006689A9 /* different-headers.json in Resources */,
 				BB94659E224BBCEB0004F29B /* upload-file.json in Resources */,
 				ED7862AD1F7D44EB00CB2625 /* example.json in Resources */,
 				BB94659C224BBCEB0004F29B /* testfile.txt in Resources */,
@@ -506,6 +512,7 @@
 				BB946590224BBCEA0004F29B /* json-example.json in Resources */,
 				BB946591224BBCEA0004F29B /* multiple.json in Resources */,
 				BB946593224BBCEA0004F29B /* text.json in Resources */,
+				DB256BA92666AEBB006689A9 /* different-headers.json in Resources */,
 				BB946594224BBCEA0004F29B /* upload-file.json in Resources */,
 				ED78629F1F7D44EA00CB2625 /* example.json in Resources */,
 				BB946592224BBCEA0004F29B /* testfile.txt in Resources */,
@@ -528,6 +535,7 @@
 				BB946595224BBCEB0004F29B /* json-example.json in Resources */,
 				BB946596224BBCEB0004F29B /* multiple.json in Resources */,
 				BB946598224BBCEB0004F29B /* text.json in Resources */,
+				DB256BAA2666AEBB006689A9 /* different-headers.json in Resources */,
 				BB946599224BBCEB0004F29B /* upload-file.json in Resources */,
 				ED7862A61F7D44EB00CB2625 /* example.json in Resources */,
 				BB946597224BBCEB0004F29B /* testfile.txt in Resources */,

--- a/Sources/DVR/Cassette.swift
+++ b/Sources/DVR/Cassette.swift
@@ -18,7 +18,7 @@ struct Cassette {
 
     // MARK: - Functions
 
-    func interactionForRequest(_ request: URLRequest, requiredHeaders: [String] = []) -> Interaction? {
+    func interactionForRequest(_ request: URLRequest, headersToCheck: [String] = []) -> Interaction? {
         var match: Interaction?
         for interaction in interactions {
             let interactionRequest = interaction.request
@@ -29,7 +29,7 @@ struct Cassette {
 
                 // Overwrite the current match if the required headers are equal.
                 if match == nil ||
-                    interactionRequest.hasHeadersEqualToThatOfRequest(request, headersToCheck: requiredHeaders) {
+                    interactionRequest.hasHeadersEqualToThatOfRequest(request, headersToCheck: headersToCheck) {
                     match = interaction
                 }
             }

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -14,7 +14,7 @@ open class Session: URLSession {
     open var recordingEnabled = true
 
     private let testBundle: Bundle
-    private let requiredHeaders: [String]
+    private let headersToCheck: [String]
 
     private var recording = false
     private var needsPersistence = false
@@ -28,12 +28,12 @@ open class Session: URLSession {
 
     // MARK: - Initializers
 
-    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: Bundle = Session.defaultTestBundle!, backingSession: URLSession = URLSession.shared, requiredHeaders: [String] = []) {
+    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: Bundle = Session.defaultTestBundle!, backingSession: URLSession = URLSession.shared, headersToCheck: [String] = []) {
         self.outputDirectory = outputDirectory
         self.cassetteName = cassetteName
         self.testBundle = testBundle
         self.backingSession = backingSession
-        self.requiredHeaders = requiredHeaders
+        self.headersToCheck = headersToCheck
         super.init()
     }
 
@@ -160,7 +160,7 @@ open class Session: URLSession {
 
     private func addDataTask(_ request: URLRequest, completionHandler: ((Data?, Foundation.URLResponse?, NSError?) -> Void)? = nil) -> URLSessionDataTask {
         let modifiedRequest = backingSession.configuration.httpAdditionalHeaders.map(request.appending) ?? request
-        let task = SessionDataTask(session: self, request: modifiedRequest, requiredHeaders: requiredHeaders, completion: completionHandler)
+        let task = SessionDataTask(session: self, request: modifiedRequest, headersToCheck: headersToCheck, completion: completionHandler)
         addTask(task)
         return task
     }

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -14,6 +14,7 @@ open class Session: URLSession {
     open var recordingEnabled = true
 
     private let testBundle: Bundle
+    private let requiredHeaders: [String]
 
     private var recording = false
     private var needsPersistence = false
@@ -27,11 +28,12 @@ open class Session: URLSession {
 
     // MARK: - Initializers
 
-    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: Bundle = Session.defaultTestBundle!, backingSession: URLSession = URLSession.shared) {
+    public init(outputDirectory: String = "~/Desktop/DVR/", cassetteName: String, testBundle: Bundle = Session.defaultTestBundle!, backingSession: URLSession = URLSession.shared, requiredHeaders: [String] = []) {
         self.outputDirectory = outputDirectory
         self.cassetteName = cassetteName
         self.testBundle = testBundle
         self.backingSession = backingSession
+        self.requiredHeaders = requiredHeaders
         super.init()
     }
 
@@ -158,7 +160,7 @@ open class Session: URLSession {
 
     private func addDataTask(_ request: URLRequest, completionHandler: ((Data?, Foundation.URLResponse?, NSError?) -> Void)? = nil) -> URLSessionDataTask {
         let modifiedRequest = backingSession.configuration.httpAdditionalHeaders.map(request.appending) ?? request
-        let task = SessionDataTask(session: self, request: modifiedRequest, completion: completionHandler)
+        let task = SessionDataTask(session: self, request: modifiedRequest, requiredHeaders: requiredHeaders, completion: completionHandler)
         addTask(task)
         return task
     }

--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -11,6 +11,7 @@ final class SessionDataTask: URLSessionDataTask {
 
     weak var session: Session!
     let request: URLRequest
+    let requiredHeaders: [String]
     let completion: Completion?
     private let queue = DispatchQueue(label: "com.venmo.DVR.sessionDataTaskQueue", attributes: [])
     private var interaction: Interaction?
@@ -26,9 +27,10 @@ final class SessionDataTask: URLSessionDataTask {
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, completion: (Completion)? = nil) {
+    init(session: Session, request: URLRequest, requiredHeaders: [String] = [], completion: (Completion)? = nil) {
         self.session = session
         self.request = request
+        self.requiredHeaders = requiredHeaders
         self.completion = completion
     }
 
@@ -43,7 +45,7 @@ final class SessionDataTask: URLSessionDataTask {
         let cassette = session.cassette
 
         // Find interaction
-        if let interaction = session.cassette?.interactionForRequest(request) {
+        if let interaction = session.cassette?.interactionForRequest(request, requiredHeaders: requiredHeaders) {
             self.interaction = interaction
             // Forward completion
             if let completion = completion {

--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -11,7 +11,7 @@ final class SessionDataTask: URLSessionDataTask {
 
     weak var session: Session!
     let request: URLRequest
-    let requiredHeaders: [String]
+    let headersToCheck: [String]
     let completion: Completion?
     private let queue = DispatchQueue(label: "com.venmo.DVR.sessionDataTaskQueue", attributes: [])
     private var interaction: Interaction?
@@ -27,10 +27,10 @@ final class SessionDataTask: URLSessionDataTask {
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, requiredHeaders: [String] = [], completion: (Completion)? = nil) {
+    init(session: Session, request: URLRequest, headersToCheck: [String] = [], completion: (Completion)? = nil) {
         self.session = session
         self.request = request
-        self.requiredHeaders = requiredHeaders
+        self.headersToCheck = headersToCheck
         self.completion = completion
     }
 
@@ -45,7 +45,7 @@ final class SessionDataTask: URLSessionDataTask {
         let cassette = session.cassette
 
         // Find interaction
-        if let interaction = session.cassette?.interactionForRequest(request, requiredHeaders: requiredHeaders) {
+        if let interaction = session.cassette?.interactionForRequest(request, headersToCheck: headersToCheck) {
             self.interaction = interaction
             // Forward completion
             if let completion = completion {

--- a/Sources/DVR/SessionDownloadTask.swift
+++ b/Sources/DVR/SessionDownloadTask.swift
@@ -10,14 +10,16 @@ final class SessionDownloadTask: URLSessionDownloadTask {
 
     weak var session: Session!
     let request: URLRequest
+    let requiredHeaders: [String]
     let completion: Completion?
 
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, completion: Completion? = nil) {
+    init(session: Session, request: URLRequest, requiredHeaders: [String] = [], completion: Completion? = nil) {
         self.session = session
         self.request = request
+        self.requiredHeaders = requiredHeaders
         self.completion = completion
     }
 
@@ -28,7 +30,7 @@ final class SessionDownloadTask: URLSessionDownloadTask {
     }
 
     override func resume() {
-        let task = SessionDataTask(session: session, request: request) { data, response, error in
+        let task = SessionDataTask(session: session, request: request, requiredHeaders: requiredHeaders) { data, response, error in
             let location: URL?
             if let data = data {
                 // Write data to temporary file

--- a/Sources/DVR/SessionDownloadTask.swift
+++ b/Sources/DVR/SessionDownloadTask.swift
@@ -10,16 +10,16 @@ final class SessionDownloadTask: URLSessionDownloadTask {
 
     weak var session: Session!
     let request: URLRequest
-    let requiredHeaders: [String]
+    let headersToCheck: [String]
     let completion: Completion?
 
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, requiredHeaders: [String] = [], completion: Completion? = nil) {
+    init(session: Session, request: URLRequest, headersToCheck: [String] = [], completion: Completion? = nil) {
         self.session = session
         self.request = request
-        self.requiredHeaders = requiredHeaders
+        self.headersToCheck = headersToCheck
         self.completion = completion
     }
 
@@ -30,7 +30,7 @@ final class SessionDownloadTask: URLSessionDownloadTask {
     }
 
     override func resume() {
-        let task = SessionDataTask(session: session, request: request, requiredHeaders: requiredHeaders) { data, response, error in
+        let task = SessionDataTask(session: session, request: request, headersToCheck: headersToCheck) { data, response, error in
             let location: URL?
             if let data = data {
                 // Write data to temporary file

--- a/Sources/DVR/SessionUploadTask.swift
+++ b/Sources/DVR/SessionUploadTask.swift
@@ -10,18 +10,18 @@ final class SessionUploadTask: URLSessionUploadTask {
 
     weak var session: Session!
     let request: URLRequest
-    let requiredHeaders: [String]
+    let headersToCheck: [String]
     let completion: Completion?
     let dataTask: SessionDataTask
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, requiredHeaders: [String] = [], completion: Completion? = nil) {
+    init(session: Session, request: URLRequest, headersToCheck: [String] = [], completion: Completion? = nil) {
         self.session = session
         self.request = request
-        self.requiredHeaders = requiredHeaders
+        self.headersToCheck = headersToCheck
         self.completion = completion
-        dataTask = SessionDataTask(session: session, request: request, requiredHeaders: requiredHeaders, completion: completion)
+        dataTask = SessionDataTask(session: session, request: request, headersToCheck: headersToCheck, completion: completion)
     }
 
     // MARK: - URLSessionTask

--- a/Sources/DVR/SessionUploadTask.swift
+++ b/Sources/DVR/SessionUploadTask.swift
@@ -10,16 +10,18 @@ final class SessionUploadTask: URLSessionUploadTask {
 
     weak var session: Session!
     let request: URLRequest
+    let requiredHeaders: [String]
     let completion: Completion?
     let dataTask: SessionDataTask
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, completion: Completion? = nil) {
+    init(session: Session, request: URLRequest, requiredHeaders: [String] = [], completion: Completion? = nil) {
         self.session = session
         self.request = request
+        self.requiredHeaders = requiredHeaders
         self.completion = completion
-        dataTask = SessionDataTask(session: session, request: request, completion: completion)
+        dataTask = SessionDataTask(session: session, request: request, requiredHeaders: requiredHeaders, completion: completion)
     }
 
     // MARK: - URLSessionTask

--- a/Tests/DVRTests/Fixtures/different-headers.json
+++ b/Tests/DVRTests/Fixtures/different-headers.json
@@ -1,0 +1,62 @@
+{
+  "interactions" : [
+    {
+      "recorded_at" : 1434688721.440751,
+      "response" : {
+        "body" : "hello",
+        "status" : 200,
+        "url" : "http:\/\/example.com\/",
+        "headers" : {
+          "Cache-Control" : "max-age=604800",
+          "Content-Type" : "text\/plain",
+          "Server" : "ECS (rhv\/818F)",
+          "Last-Modified" : "Fri, 09 Aug 2013 23:54:35 GMT",
+          "X-Cache" : "HIT",
+          "x-ec-custom-error" : "1",
+          "Accept-Ranges" : "bytes",
+          "Date" : "Fri, 19 Jun 2015 04:38:41 GMT",
+          "Content-Length" : "5",
+          "Expires" : "Fri, 26 Jun 2015 04:38:41 GMT",
+          "Etag" : "\"359670651\""
+        }
+      },
+      "request" : {
+        "method" : "GET",
+        "url" : "http:\/\/example.com",
+        "headers" : {
+          "Foo" : "Bar1"
+        }
+      }
+    },
+    {
+      "recorded_at" : 1434688721.440751,
+      "response" : {
+        "body" : "hello again",
+        "status" : 200,
+        "url" : "http:\/\/example.com\/",
+        "headers" : {
+          "Cache-Control" : "max-age=604800",
+          "Content-Type" : "text\/plain",
+          "Server" : "ECS (rhv\/818F)",
+          "Last-Modified" : "Fri, 09 Aug 2013 23:54:35 GMT",
+          "X-Cache" : "HIT",
+          "x-ec-custom-error" : "1",
+          "Accept-Ranges" : "bytes",
+          "Date" : "Fri, 19 Jun 2015 04:38:41 GMT",
+          "Content-Length" : "5",
+          "Expires" : "Fri, 26 Jun 2015 04:38:41 GMT",
+          "Etag" : "\"359670651\""
+        }
+      },
+      "request" : {
+        "method" : "GET",
+        "url" : "http:\/\/example.com",
+        "headers" : {
+          "Foo" : "Bar2"
+        }
+      }
+    }
+  ],
+  "name" : "different-headers"
+}
+

--- a/Tests/DVRTests/SessionTests.swift
+++ b/Tests/DVRTests/SessionTests.swift
@@ -240,7 +240,7 @@ class SessionTests: XCTestCase {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = ["testSessionHeader": "testSessionHeaderValue"]
         let backingSession = URLSession(configuration: configuration)
-        let session = Session(cassetteName: "different-headers", backingSession: backingSession, requiredHeaders: ["Foo"])
+        let session = Session(cassetteName: "different-headers", backingSession: backingSession, headersToCheck: ["Foo"])
         session.recordingEnabled = false
 
         var request = URLRequest(url: URL(string: "http://example.com")!)


### PR DESCRIPTION
This package would be more helpful if it distinguished between identical requests with different headers. To accomplish this, we can add a new optional parameter to `Session` called `requiredHeaders`:

```
Session(
    cassetteName: "my-cassette", 
    backingSession: aBackingSession,
    requiredHeaders: ["some-header-that-might-warrant-a-different-response"]
)
```

Only the headers specified in the `requiredHeaders` parameter will be used to select the response in the cassette. This is because other request headers (like User-Agent) change often and would make testing more difficult. This is useful when a test needs to hit the same endpoint multiple times and expects different responses based on the request headers.